### PR TITLE
Don't complain about an async function that uses for await (foo of bar) {...}

### DIFF
--- a/no-async-without-await.js
+++ b/no-async-without-await.js
@@ -56,9 +56,18 @@ module.exports = context => {
       frame.foundAwait = true;
     },
 
+    // babel-eslint
     ForAwaitStatement(node) {
       const frame = stack[stack.length - 1];
       frame.foundAwait = true;
+    },
+
+    // espree
+    ForOfStatement(node) {
+      if (node.await) {
+        const frame = stack[stack.length - 1];
+        frame.foundAwait = true;
+      }
     },
   };
 };

--- a/no-async-without-await.js
+++ b/no-async-without-await.js
@@ -55,6 +55,11 @@ module.exports = context => {
       const frame = stack[stack.length - 1];
       frame.foundAwait = true;
     },
+
+    ForAwaitStatement(node) {
+      const frame = stack[stack.length - 1];
+      frame.foundAwait = true;
+    },
   };
 };
 

--- a/test/no-async-without-await-test.js
+++ b/test/no-async-without-await-test.js
@@ -24,6 +24,7 @@ ruleTester.run('no-async-without-await', require.resolve('../no-async-without-aw
     {code: 'async () => { await x }'},
     {code: 'class C { async m() { await x } }'},
     {code: 'class C { static async m() { await x } }'},
+    {code: 'async function foo() { for await (const x of y) {} }'},
 
     {code: 'throw x'},
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of

This supports both `babel-eslint`'s `ForAwaitStatement` ast node as well as [the standard `ForOfStatement` with `await: true`](https://github.com/estree/estree/blob/master/es2018.md#statements).

Would be nice to move this project forward to use the newest eslint and ditch babel-eslint in development.